### PR TITLE
Support head size 192

### DIFF
--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -700,6 +700,9 @@ void paged_attention_v1_launcher(
     case 160:
       LAUNCH_PAGED_ATTENTION_V1(160);
       break;
+    case 192:
+      LAUNCH_PAGED_ATTENTION_V1(192);
+      break;
     case 256:
       LAUNCH_PAGED_ATTENTION_V1(256);
       break;
@@ -894,6 +897,9 @@ void paged_attention_v2_launcher(
       break;
     case 160:
       LAUNCH_PAGED_ATTENTION_V2(160);
+      break;
+    case 192:
+      LAUNCH_PAGED_ATTENTION_V2(192);
       break;
     case 256:
       LAUNCH_PAGED_ATTENTION_V2(256);

--- a/csrc/cpu/attention.cpp
+++ b/csrc/cpu/attention.cpp
@@ -390,6 +390,9 @@ void paged_attention_v1_impl_launcher(
   case 160:
     LAUNCH_V1_ATTENTION_KERNEL(T, 160, BLOCK_SIZE);
     break;
+  case 192:
+    LAUNCH_V1_ATTENTION_KERNEL(T, 192, BLOCK_SIZE);
+    break;
   case 256:
     LAUNCH_V1_ATTENTION_KERNEL(T, 256, BLOCK_SIZE);
     break;


### PR DESCRIPTION
Needed for Deepseek V2 to avoid unnecessary padding.

